### PR TITLE
Fixed Typos in README, Class Name, String Key

### DIFF
--- a/README.md
+++ b/README.md
@@ -149,7 +149,7 @@ Rules of thumb:
 
 * All rest calls from angular ui go via java-proxy. Java proxy transparently forwards to backends.
 * In the new angular CRUD-ui (searching, creating, modifying and deleting whois objects) we stick to the "whoisresources-objects-object"-protocol.
-  So when searching for maintainers of sso-user, we return a regular search result. What todo with the star?
+  So when searching for maintainers of sso-user, we return a regular search result. What to do with the star?
   For the service that delivers info for the upper-right-sso-info, we use a dedicated protocol.
 * When designing new urls for the java-proxy, stick to the whois conventions
 * UI should be as simple as possible: So fetching or pushing information should be done with a single call. The java proxy can aggregate to achieve this.
@@ -163,7 +163,7 @@ Responsibilities of java-proxy: Non-functional requirements only
 * Same origin
 * Api-key to backends
 * Caching
-* Flexibilty: fix whois problems temporarily
+* Flexibility: fix whois problems temporarily
 
 
 Things every db-web-ui developer should know

--- a/backend/src/main/java/net/ripe/whois/CustomStartStopEventListener.java
+++ b/backend/src/main/java/net/ripe/whois/CustomStartStopEventListener.java
@@ -7,8 +7,8 @@ import org.springframework.context.event.ContextRefreshedEvent;
 import org.springframework.context.event.EventListener;
 import org.springframework.stereotype.Component;
 
-@Component("customStartStopEventListner")
-public class CustomStartStopEventListner {
+@Component("customStartStopEventListener")
+public class CustomStartStopEventListener {
 
     final private LoadBalancerEnabler loadBalancerEnabler;
 
@@ -16,7 +16,7 @@ public class CustomStartStopEventListner {
     private int preShutdownPause;
 
     @Autowired
-    public CustomStartStopEventListner(final LoadBalancerEnabler loadBalancerEnabler) {
+    public CustomStartStopEventListener(final LoadBalancerEnabler loadBalancerEnabler) {
         this.loadBalancerEnabler = loadBalancerEnabler;
     }
 

--- a/frontend/src/app/fulltextsearch/full-text-search.component.ts
+++ b/frontend/src/app/fulltextsearch/full-text-search.component.ts
@@ -145,7 +145,7 @@ export class FullTextSearchComponent implements OnInit, OnDestroy {
         this.resultSummary = responseModel.summary;
         this.whoisVersion = this.fullTextResponseService.getVersionFromResponse(resp);
         if (this.results.length === 0) {
-            this.alertsService.setGlobalWarning(Labels['fullText.emptyRresult.text']);
+            this.alertsService.setGlobalWarning(Labels['fullText.emptyResult.text']);
         }
     }
 

--- a/frontend/src/app/label.constants.ts
+++ b/frontend/src/app/label.constants.ts
@@ -13,7 +13,7 @@ export const Labels = {
     'fullText.attributeHelpText.title':
         'Only objects where search string is contained within specified fields are returned in result set, but all attributes containing the search string within those objects are reported',
     'fullText.emptyQueryText.text': 'Empty query - please specify at least one character',
-    'fullText.emptyRresult.text': 'No results were found for your search. Your search details may be too selective.',
+    'fullText.emptyResult.text': 'No results were found for your search. Your search details may be too selective.',
 
     'lookup.ripeManagedValuesCheckbox.text': 'Highlight RIPE NCC managed values',
     'lookup.ripestatLink.text': 'RIPEstat',


### PR DESCRIPTION
This pull request includes several changes focused on improving code quality, fixing typos, and ensuring consistency across the codebase. The most important changes include correcting spelling errors, renaming a file and class for consistency, and fixing a typo in a user-facing label.

### Code quality and consistency improvements:
* Renamed the file `CustomStartStopEventListner.java` to `CustomStartStopEventListener.java` and updated the class name and `@Component` annotation to match the corrected spelling. This ensures consistency in naming conventions.

### Typo fixes:
* Fixed a typo in the `README.md` file by correcting "Flexibilty" to "Flexibility" in the responsibilities list.
* Corrected a typo in the label key and value from `fullText.emptyRresult.text` to `fullText.emptyResult.text` in `label.constants.ts`.
* Updated the usage of the corrected label key `fullText.emptyResult.text` in `full-text-search.component.ts` to match the change in `label.constants.ts`.