### PR TITLE
Display Conditional in Object Template

### DIFF
--- a/backend/pom.xml
+++ b/backend/pom.xml
@@ -43,8 +43,8 @@
         <snakeyaml.version>2.3</snakeyaml.version>
         <!-- keep spring-boot.version in sync with parent pom -->
         <spring-boot.version>3.5.3</spring-boot.version>
-        <!-- whois 1.118 release -->
-        <whois.version>505c5f7a</whois.version>
+        <!-- whois master 13-oct -->
+        <whois.version>9a1a7dfc</whois.version>
     </properties>
 
     <dependencyManagement>


### PR DESCRIPTION
A boolean mandatory: true or false is being used for displaying those attributes that are required when creating/updating an object
reading the RFC https://datatracker.ietf.org/doc/html/rfc2622 makes sense to me. Mandatory: true will be when we know that the attribute is required. Mandatory: false will be when the attribute is optional or conditional.

If we decide to change this, we should replicate the business logic when conditional (just to know if we should display the attribute or not as we do with mandatory - to know if that conditional is mandatory or not). 

I don't think this is needed because the user could always add the "conditional" attribute if needed, when errors are thrown from backend.

We just need to make sure that the Condition is display in the object template, so the user can know before hand which is a conditional attribute. For that, it is enough just adding the whois dependency because the templates are being taken from whois dependency.