### PR TITLE
DB-4911 make sure log dir exists

### DIFF
--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -1,6 +1,8 @@
 #!/bin/sh
 set -e
 
+mkdir -p /app/var/logs/jetty
+
 JAVA_OPTS="
     -Xms${START_HEAP_SIZE}
     -Xmx${MAX_HEAP_SIZE}


### PR DESCRIPTION
This fixes error `Caused by: java.io.IOException: Log directory does not exist. Path=/app/var/logs/jetty` on new containerized setup.
