### PR TITLE
DB-4911 CI_COMMIT_SHORT_SHA is used for dev container deployment

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -55,9 +55,9 @@ build-container:
         docker build
         --pull
         --build-arg CI_COMMIT_SHA=$CI_COMMIT_SHA
-        --tag $CI_REGISTRY_IMAGE:$CI_COMMIT_SHA
+        --tag $CI_REGISTRY_IMAGE:$CI_COMMIT_SHORT_SHA
         .
-    - docker push $CI_REGISTRY_IMAGE:$CI_COMMIT_SHA
+    - docker push $CI_REGISTRY_IMAGE:$CI_COMMIT_SHORT_SHA
 
 backend:
     tags:
@@ -181,8 +181,8 @@ release-container:
     before_script:
       - echo -n $CI_JOB_TOKEN | docker login -u gitlab-ci-token --password-stdin $CI_REGISTRY
     script:
-      - docker pull $CI_REGISTRY_IMAGE:$CI_COMMIT_SHA
-      - docker tag $CI_REGISTRY_IMAGE:$CI_COMMIT_SHA $CI_REGISTRY_IMAGE:$CI_COMMIT_REF_NAME
+      - docker pull $CI_REGISTRY_IMAGE:$CI_COMMIT_SHORT_SHA
+      - docker tag $CI_REGISTRY_IMAGE:$CI_COMMIT_SHORT_SHA $CI_REGISTRY_IMAGE:$CI_COMMIT_REF_NAME
       - docker push $CI_REGISTRY_IMAGE:$CI_COMMIT_REF_NAME
 
 browserstack:


### PR DESCRIPTION
To make it consistent with other containarized applications use SHORT_SHA for dev image tag